### PR TITLE
Feature: log wrapped token on mint and burn

### DIFF
--- a/contracts/Router/Router.sol
+++ b/contracts/Router/Router.sol
@@ -35,6 +35,7 @@ contract Router is FeeCalculator {
     /// @notice An event emitted once a Mint transaction is executed
     event Mint(
         address indexed account,
+        address indexed wrappedToken,
         uint256 amount,
         uint256 serviceFeeInWTokens,
         uint256 txCost,
@@ -44,6 +45,7 @@ contract Router is FeeCalculator {
     /// @notice An event emitted once a Burn transaction is executed
     event Burn(
         address indexed account,
+        address indexed wrappedToken,
         uint256 amount,
         uint256 serviceFee,
         bytes receiver
@@ -127,7 +129,14 @@ contract Router is FeeCalculator {
             receiver,
             amountToMint
         );
-        emit Mint(receiver, amount, serviceFeeInWTokens, 0, transactionId);
+        emit Mint(
+            receiver,
+            wrappedToken,
+            amountToMint,
+            serviceFeeInWTokens,
+            0,
+            transactionId
+        );
     }
 
     /**
@@ -182,7 +191,14 @@ contract Router is FeeCalculator {
             receiver,
             amountToMint
         );
-        emit Mint(receiver, amount, serviceFeeInWTokens, txCost, transactionId);
+        emit Mint(
+            receiver,
+            wrappedToken,
+            amountToMint,
+            serviceFeeInWTokens,
+            txCost,
+            transactionId
+        );
     }
 
     /**
@@ -209,7 +225,13 @@ contract Router is FeeCalculator {
         );
         uint256 bridgedAmount = amount.sub(serviceFeeInWTokens);
 
-        emit Burn(msg.sender, bridgedAmount, serviceFeeInWTokens, receiver);
+        emit Burn(
+            msg.sender,
+            wrappedToken,
+            bridgedAmount,
+            serviceFeeInWTokens,
+            receiver
+        );
     }
 
     function claim(address wrappedToken) public onlyMember {

--- a/test/router.js
+++ b/test/router.js
@@ -477,6 +477,7 @@ describe("Router", function () {
                 expectedEvent,
                 [
                     receiver,
+                    wrappedTokenInstance.contractAddress,
                     expectedAmount,
                     expectedServiceFee,
                     hederaAddress


### PR DESCRIPTION
* add wrapped token in logs for mint and burn (indexed, in case someone would like to search per wrapped token)
* fix: mint log amount to be actual minted